### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const os = require('os');
 const debug = require('debug')('wicked-sdk');
 const request = require('request');
 const qs = require('querystring');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 // ====== VARIABLES ======
 

--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
   },
   "homepage": "https://github.com/Haufe-Lexware/wicked.node-sdk#readme",
   "dependencies": {
-    "debug": "2.2.0", 
+    "debug": "2.2.0",
+    "node-uuid": "1.4.7",
     "request": "2.74.0",
-    "node-uuid": "1.4.7"
+    "uuid": "^3.0.0"
   },
   "jshintConfig": {
-    "node": true, 
+    "node": true,
     "esversion": 6
-  } 
+  }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.