### PR TITLE
Fixing compilation. Before, tsc (3.0.3) was ...

### DIFF
--- a/src/kong.ts
+++ b/src/kong.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { URL } from "url";
 import { KongService, KongRoute, KongApi, ProtocolType } from "./kong-interfaces";
 
 /** @hidden */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
         "types": [
             "node"
         ],
+        "lib": [
+            "es6"
+        ],
         "outDir": "./dist",
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
... reporting an error due to a duplicate declaration of console from
both the dom and node libraries.